### PR TITLE
Supporting a primary_goal when adding an Action

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/ChooseActionsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ChooseActionsActivity.java
@@ -39,7 +39,6 @@ import org.tndata.android.compass.ui.parallaxrecyclerview.HeaderLayoutManagerFix
 import org.tndata.android.compass.util.CompassTagHandler;
 import org.tndata.android.compass.util.Constants;
 
-import java.util.ArrayList;
 import java.util.List;
 
 
@@ -210,7 +209,7 @@ public class ChooseActionsActivity
     @Override
     public void addAction(Action action){
         Toast.makeText(getApplicationContext(), getText(R.string.action_saving), Toast.LENGTH_SHORT).show();
-        new AddActionTask(this, this, action).execute();
+        new AddActionTask(this, this, mGoal, action).execute();
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/LearnMoreFragment.java
@@ -27,7 +27,6 @@ import org.tndata.android.compass.ui.CompassPopupMenu;
 import org.tndata.android.compass.util.CompassTagHandler;
 import org.tndata.android.compass.util.ImageHelper;
 
-import java.util.ArrayList;
 import java.util.List;
 
 
@@ -137,7 +136,7 @@ public class LearnMoreFragment extends Fragment implements AddActionTask
                     if (!actions.contains(mAction)) {
                         mProgressBar.setVisibility(View.VISIBLE);
                         mAddImageView.setEnabled(false);
-                        new AddActionTask(getActivity(), LearnMoreFragment.this, mAction)
+                        new AddActionTask(getActivity(), LearnMoreFragment.this, mGoal, mAction)
                                 .executeOnExecutor(AsyncTask
                                         .THREAD_POOL_EXECUTOR);
                     } else {

--- a/src/main/java/org/tndata/android/compass/task/AddActionTask.java
+++ b/src/main/java/org/tndata/android/compass/task/AddActionTask.java
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 import org.tndata.android.compass.CompassApplication;
 import org.tndata.android.compass.model.Action;
 import org.tndata.android.compass.model.Behavior;
+import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.util.Constants;
 import org.tndata.android.compass.util.NetworkHelper;
 
@@ -22,7 +23,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +30,7 @@ import java.util.Map;
 public class AddActionTask extends AsyncTask<Void, Void, Action> {
     private Context mContext;
     private Action mAction;
+    private Goal mGoal;
     private AddActionTaskListener mCallback;
     private static Gson gson = new GsonBuilder().setFieldNamingPolicy(
             FieldNamingPolicy.IDENTITY).create();
@@ -41,6 +42,14 @@ public class AddActionTask extends AsyncTask<Void, Void, Action> {
     public AddActionTask(Context context, AddActionTaskListener callback, Action action) {
         mContext = context;
         mCallback = callback;
+        mGoal = null;
+        mAction = action;
+    }
+
+    public AddActionTask(Context context, AddActionTaskListener callback, Goal goal, Action action) {
+        mContext = context;
+        mCallback = callback;
+        mGoal = goal;
         mAction = action;
     }
 
@@ -62,6 +71,9 @@ public class AddActionTask extends AsyncTask<Void, Void, Action> {
         JSONObject body = new JSONObject();
         try {
             body.put("action", mAction.getId());
+            if(mGoal != null) {
+                body.put("primary_goal", mGoal.getId());
+            }
         } catch (JSONException e1) {
             e1.printStackTrace();
             return null;


### PR DESCRIPTION
This updates the ChooseActionsActivity and the AddActionTask so that it sends a goal id back to the api (if a goal is available) as the `primary_goal`.
