### PR TITLE
Remove the MAC address lookup when sending GCM registration info to t…

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -24,7 +24,6 @@
         android:maxSdkVersion="18" />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 

--- a/src/main/java/org/tndata/android/compass/util/API.java
+++ b/src/main/java/org/tndata/android/compass/util/API.java
@@ -101,13 +101,11 @@ public abstract class API{
         return BASE_URL + "notifications/devices/";
     }
 
-    public static JSONObject getPostDeviceRegistrationBody(@NonNull String registrationId,
-                                                           @NonNull String deviceId){
+    public static JSONObject getPostDeviceRegistrationBody(@NonNull String registrationId){
         JSONObject postDeviceRegistrationBody = new JSONObject();
         try{
             postDeviceRegistrationBody.put("registration_id", registrationId)
-                    .put("device_name", Build.MANUFACTURER + " " + Build.PRODUCT)
-                    .put("device_id", deviceId);
+                    .put("device_name", Build.MANUFACTURER + " " + Build.PRODUCT);
         }
         catch (JSONException jsonx){
             jsonx.printStackTrace();

--- a/src/main/java/org/tndata/android/compass/util/GcmRegistration.java
+++ b/src/main/java/org/tndata/android/compass/util/GcmRegistration.java
@@ -5,8 +5,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.net.wifi.WifiInfo;
-import android.net.wifi.WifiManager;
 import android.os.AsyncTask;
 import android.util.Log;
 
@@ -164,12 +162,9 @@ public class GcmRegistration{
     }
 
     private void sendRegistrationIdToBackend(String registration_id){
-        WifiManager manager = (WifiManager)mContext.getSystemService(Context.WIFI_SERVICE);
-        WifiInfo info = manager.getConnectionInfo();
-        String address = info.getMacAddress();
         NetworkRequest.post(mContext, null, API.getPostDeviceRegistrationUrl(),
                 ((CompassApplication)mContext.getApplicationContext()).getToken(),
-                API.getPostDeviceRegistrationBody(registration_id, address));
+                API.getPostDeviceRegistrationBody(registration_id));
     }
 
     /**


### PR DESCRIPTION
…he api; We now rely on the api to do the right when with just the registration_id and device_name
